### PR TITLE
fix(vscode): support VS Code shared storage WAL

### DIFF
--- a/plugins/vscode/src/files.ts
+++ b/plugins/vscode/src/files.ts
@@ -1,6 +1,7 @@
-import { readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Database } from "sql.js";
 import { join } from "path";
+import { env } from "process";
 
 // 指定路径 (相对于 dist 目录)
 const sqlWasmDir = join(__dirname, "third_party/sqljs");
@@ -10,6 +11,7 @@ const sqlWasmJsPath = join(sqlWasmDir, "sql-wasm.js");
 const sqlWasmCode = readFileSync(sqlWasmJsPath, "utf8");
 // eslint-disable-next-line no-new-func
 const initSqlJs = new Function("require", "module", "exports", sqlWasmCode + "\nreturn module.exports;")(require, { exports: {} }, {}).default || require;
+const RECENTLY_OPENED_STORAGE_KEY = "history.recentlyOpenedPathsList";
 
 export interface Recent {
   entries: Entry[];
@@ -28,18 +30,154 @@ export interface Workspace {
   configPath: string;
 }
 
-export async function GetFiles(path: string) {
+function getVSCodeSharedStoragePath(): string {
+  const home = env.USERPROFILE || env.HOME;
+  return home ? join(home, ".vscode-shared", "sharedStorage", "state.vscdb") : "";
+}
+
+function shouldFallbackToVSCodeSharedStorage(dbPath: string): boolean {
+  const normalized = dbPath.replace(/\\/g, "/").toLowerCase();
+  return normalized.endsWith("/code/user/globalstorage/state.vscdb");
+}
+
+function getStorageCandidates(dbPath: string): string[] {
+  const candidates = [dbPath];
+  const sharedStoragePath = getVSCodeSharedStoragePath();
+
+  if (
+    sharedStoragePath &&
+    existsSync(sharedStoragePath) &&
+    shouldFallbackToVSCodeSharedStorage(dbPath) &&
+    !candidates.includes(sharedStoragePath)
+  ) {
+    candidates.push(sharedStoragePath);
+  }
+
+  return candidates;
+}
+
+function readUInt32BE(buffer: Buffer, offset: number): number {
+  return buffer.readUInt32BE(offset);
+}
+
+function getSQLitePageSize(dbBuffer: Buffer): number {
+  if (dbBuffer.length < 100) {
+    return 4096;
+  }
+
+  const pageSize = dbBuffer.readUInt16BE(16);
+  return pageSize === 1 ? 65536 : pageSize;
+}
+
+function readDatabaseWithWal(dbPath: string): Buffer {
+  const dbBuffer = readFileSync(dbPath);
+  const walPath = `${dbPath}-wal`;
+
+  if (!existsSync(walPath)) {
+    return dbBuffer;
+  }
+
+  const walBuffer = readFileSync(walPath);
+  if (walBuffer.length < 32) {
+    return dbBuffer;
+  }
+
+  const magic = readUInt32BE(walBuffer, 0);
+  if (magic !== 0x377f0682 && magic !== 0x377f0683) {
+    throw new Error(`无法识别 SQLite WAL 文件: ${walPath}`);
+  }
+
+  const walPageSize = readUInt32BE(walBuffer, 8);
+  const pageSize = walPageSize || getSQLitePageSize(dbBuffer);
+  if (pageSize <= 0) {
+    throw new Error(`无法读取 SQLite WAL page size: ${walPath}`);
+  }
+
+  const salt1 = readUInt32BE(walBuffer, 16);
+  const salt2 = readUInt32BE(walBuffer, 20);
+  const frameSize = pageSize + 24;
+  let merged = Buffer.from(dbBuffer);
+  let committedPageCount = Math.ceil(merged.length / pageSize);
+  let pendingFrames: Array<{ pageNumber: number; page: Buffer }> = [];
+
+  for (let offset = 32; offset + frameSize <= walBuffer.length; offset += frameSize) {
+    const pageNumber = readUInt32BE(walBuffer, offset);
+    const frameCommitPageCount = readUInt32BE(walBuffer, offset + 4);
+    const frameSalt1 = readUInt32BE(walBuffer, offset + 8);
+    const frameSalt2 = readUInt32BE(walBuffer, offset + 12);
+
+    if (!pageNumber || frameSalt1 !== salt1 || frameSalt2 !== salt2) {
+      continue;
+    }
+
+    pendingFrames.push({
+      pageNumber,
+      page: Buffer.from(walBuffer.subarray(offset + 24, offset + 24 + pageSize)),
+    });
+
+    if (frameCommitPageCount) {
+      for (const frame of pendingFrames) {
+        const pageOffset = (frame.pageNumber - 1) * pageSize;
+        const requiredLength = pageOffset + pageSize;
+        if (merged.length < requiredLength) {
+          const expanded = Buffer.alloc(requiredLength);
+          merged.copy(expanded);
+          merged = expanded;
+        }
+
+        frame.page.copy(merged, pageOffset);
+      }
+      committedPageCount = frameCommitPageCount;
+      pendingFrames = [];
+    }
+  }
+
+  return merged.subarray(0, committedPageCount * pageSize);
+}
+
+function getRecentValue(db: Database): string {
+  const sql = `select value from ItemTable where key = '${RECENTLY_OPENED_STORAGE_KEY}'`;
+  const results = db.exec(sql);
+  const value = results?.[0]?.values?.[0]?.[0];
+
+  if (!value) {
+    throw new Error("未找到 VSCode 历史记录数据");
+  }
+
+  return value.toString();
+}
+
+async function openRecentDatabase(dbPath: string): Promise<{ db: Database; value: string; path: string }> {
   let SQL = await initSqlJs({ locateFile: (file: string) => join(sqlWasmDir, file) });
-  let db = new SQL.Database(readFileSync(path)) as Database;
-  let sql =
-    "select value from ItemTable where key = 'history.recentlyOpenedPathsList'";
-  let results = db.exec(sql);
-  let res = results[0].values.toString();
-  if (!res)
-    throw new Error(
-      "数据获取失败, 请检查 vsc-setting 配置, <br/> 注意当前仅在 vscode 1.64 版本进行过测试"
-    );
-  let data = JSON.parse(res) as Recent;
+  let lastError: Error | undefined;
+
+  for (const path of getStorageCandidates(dbPath)) {
+    let db: Database | undefined;
+    try {
+      db = new SQL.Database(readDatabaseWithWal(path)) as Database;
+      return { db, value: getRecentValue(db), path };
+    } catch (error) {
+      if (db) {
+        db.close();
+      }
+      lastError = error as Error;
+    }
+  }
+
+  throw new Error(
+    `${lastError?.message || "数据获取失败"}。请检查 database 配置；VS Code 1.118+ 需要使用 .vscode-shared/sharedStorage/state.vscdb`
+  );
+}
+
+export async function GetFiles(path: string) {
+  const { db, value } = await openRecentDatabase(path);
+  let data: Recent;
+
+  try {
+    data = JSON.parse(value) as Recent;
+  } finally {
+    db.close();
+  }
 
   return data.entries.map((file) => {
     if (typeof file === "string") return file;
@@ -55,21 +193,19 @@ export async function GetFiles(path: string) {
  * @returns 是否删除成功
  */
 export async function DeleteFiles(dbPath: string, targetPath: string): Promise<boolean> {
+  let db: Database | undefined;
+
   try {
-    // 读取数据库
-    let SQL = await initSqlJs({ locateFile: (file: string) => join(sqlWasmDir, file) });
-    let db = new SQL.Database(readFileSync(dbPath)) as Database;
-    
-    // 获取当前的历史记录
-    let sql = "select value from ItemTable where key = 'history.recentlyOpenedPathsList'";
-    let results = db.exec(sql);
-    
-    if (!results || results.length === 0 || !results[0].values[0]) {
-      throw new Error("未找到历史记录数据");
+    const opened = await openRecentDatabase(dbPath);
+    db = opened.db;
+    const { value, path } = opened;
+
+    if (existsSync(`${path}-wal`)) {
+      throw new Error("检测到 VSCode 数据库存在 WAL 文件，请先关闭 VSCode 或执行 wal_checkpoint 后再删除历史记录");
     }
     
-    let res = results[0].values[0].toString();
-    let data = JSON.parse(res) as Recent;
+    // 获取当前的历史记录
+    let data = JSON.parse(value) as Recent;
     
     // 过滤掉要删除的记录
     let originalLength = data.entries.length;
@@ -90,21 +226,22 @@ export async function DeleteFiles(dbPath: string, targetPath: string): Promise<b
     // 更新数据库
     let updatedJson = JSON.stringify(data);
     db.run(
-      "UPDATE ItemTable SET value = ? WHERE key = 'history.recentlyOpenedPathsList'",
+      `UPDATE ItemTable SET value = ? WHERE key = '${RECENTLY_OPENED_STORAGE_KEY}'`,
       [updatedJson]
     );
     
     // 保存数据库文件
     let buffer = db.export();
-    writeFileSync(dbPath, buffer);
-    
-    // 关闭数据库连接
-    db.close();
-    
+    writeFileSync(path, buffer);
+
     return true;
   } catch (error) {
     console.error("删除历史记录失败:", error);
     throw new Error(`删除历史记录失败: ${error.message}`);
+  } finally {
+    if (db) {
+      db.close();
+    }
   }
 }
 
@@ -115,21 +252,19 @@ export async function DeleteFiles(dbPath: string, targetPath: string): Promise<b
  * @returns 删除成功的记录数量
  */
 export async function DeleteMultipleFiles(dbPath: string, targetPaths: string[]): Promise<number> {
+  let db: Database | undefined;
+
   try {
-    // 读取数据库
-    let SQL = await initSqlJs({ locateFile: (file: string) => join(sqlWasmDir, file) });
-    let db = new SQL.Database(readFileSync(dbPath)) as Database;
-    
-    // 获取当前的历史记录
-    let sql = "select value from ItemTable where key = 'history.recentlyOpenedPathsList'";
-    let results = db.exec(sql);
-    
-    if (!results || results.length === 0 || !results[0].values[0]) {
-      throw new Error("未找到历史记录数据");
+    const opened = await openRecentDatabase(dbPath);
+    db = opened.db;
+    const { value, path } = opened;
+
+    if (existsSync(`${path}-wal`)) {
+      throw new Error("检测到 VSCode 数据库存在 WAL 文件，请先关闭 VSCode 或执行 wal_checkpoint 后再删除历史记录");
     }
     
-    let res = results[0].values[0].toString();
-    let data = JSON.parse(res) as Recent;
+    // 获取当前的历史记录
+    let data = JSON.parse(value) as Recent;
     
     // 过滤掉要删除的记录
     let originalLength = data.entries.length;
@@ -148,21 +283,22 @@ export async function DeleteMultipleFiles(dbPath: string, targetPaths: string[])
       // 更新数据库
       let updatedJson = JSON.stringify(data);
       db.run(
-        "UPDATE ItemTable SET value = ? WHERE key = 'history.recentlyOpenedPathsList'",
+        `UPDATE ItemTable SET value = ? WHERE key = '${RECENTLY_OPENED_STORAGE_KEY}'`,
         [updatedJson]
       );
       
       // 保存数据库文件
       let buffer = db.export();
-      writeFileSync(dbPath, buffer);
+      writeFileSync(path, buffer);
     }
-    
-    // 关闭数据库连接
-    db.close();
-    
+
     return deletedCount;
   } catch (error) {
     console.error("批量删除历史记录失败:", error);
     throw new Error(`批量删除历史记录失败: ${error.message}`);
+  } finally {
+    if (db) {
+      db.close();
+    }
   }
 }

--- a/plugins/vscode/src/ide.ts
+++ b/plugins/vscode/src/ide.ts
@@ -1,7 +1,6 @@
 import { IListItem, ListItem, Plugin } from "utools-helper";
 import { VSCode } from "./vscode";
-import { NewConfig, SaveConfig, Setting, Config } from "./setting";
-import { join } from "path";
+import { NewConfig, SaveConfig, Setting, Config, GetVSCodeStoragePath } from "./setting";
 import { Action } from "utools-helper/dist/template_plugin";
 
 // 列出所有已安装的 IDE
@@ -51,13 +50,7 @@ export function NewIDEDefault() {
 export function NewIDEVsc() {
     let config = NewConfig("vsc")
     config.command = "code"
-    config.database = join(
-        utools.getPath("appData"),
-        "Code",
-        "User",
-        "globalStorage",
-        "state.vscdb"
-    )
+    config.database = GetVSCodeStoragePath()
 
     SaveConfig(config)
 }

--- a/plugins/vscode/src/setting.ts
+++ b/plugins/vscode/src/setting.ts
@@ -1,8 +1,8 @@
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { Plugin, ListItem, IListItem, } from "utools-helper";
 import { Action } from "utools-helper/dist/template_plugin";
-import { platform } from "process";
+import { env, platform } from "process";
 import { NewIDE } from "./ide";
 
 export interface Config {
@@ -16,6 +16,25 @@ export interface Config {
   [key: string]: string | IListItem[];
 }
 
+export function GetVSCodeStoragePath(): string {
+  const home = env.USERPROFILE || env.HOME;
+  const sharedStorage = home
+    ? join(home, ".vscode-shared", "sharedStorage", "state.vscdb")
+    : "";
+
+  if (sharedStorage && existsSync(sharedStorage)) {
+    return sharedStorage;
+  }
+
+  return join(
+    utools.getPath("appData"),
+    "Code",
+    "User",
+    "globalStorage",
+    "state.vscdb"
+  );
+}
+
 // 新建配置
 export function NewConfig(code: string): Config {
   const shells = {
@@ -25,18 +44,22 @@ export function NewConfig(code: string): Config {
   }
 
   code = code.toLowerCase()
-  return {
-    code: code,
-    icon: "icon/icon.png",
-    terminal: shells[platform as keyof typeof shells],
-    command: code.toLowerCase(),
-    database: join(
+  const database = code === "vsc" || code === "vscode"
+    ? GetVSCodeStoragePath()
+    : join(
       utools.getPath("appData"),
       code.charAt(0).toUpperCase() + code.slice(1),
       "User",
       "globalStorage",
       "state.vscdb"
-    ),
+    );
+
+  return {
+    code: code,
+    icon: "icon/icon.png",
+    terminal: shells[platform as keyof typeof shells],
+    command: code.toLowerCase(),
+    database,
     timeout: "3000"
   }
 }


### PR DESCRIPTION
## Summary

Fix vscode plugin recent history loading after VS Code 1.118 moved recent workspaces to shared application storage.

Changes:
- Prefer VS Code shared storage at `.vscode-shared/sharedStorage/state.vscdb` for `vsc`/`vscode` configs.
- Fallback from existing old `Code/User/globalStorage/state.vscdb` configs to shared storage when appropriate.
- Read SQLite WAL frames into an in-memory DB image before passing it to sql.js, so recent history can be read while data is still in `state.vscdb-wal`.
- Avoid `results[0].values` crashes by checking empty query results.
- Keep delete operations conservative: if WAL exists, refuse to write and ask users to close VS Code or checkpoint first.

Fixes #151

## Validation

- TypeScript transpile check passed for touched files.
- Verified existing old-path config can fallback and read VS Code recent entries.
- Verified a live WAL-only SQLite test DB can be read through `GetFiles()`.
